### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: PR Validation Pipeline
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/homeassistant-mcp/homeassistant-mcp/security/code-scanning/1](https://github.com/homeassistant-mcp/homeassistant-mcp/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions to the minimum required. The most secure way is to set `permissions: contents: read` at the workflow root unless the job requires additional privileges. Since the job only checks out code and runs tests, the only required permission is `contents: read`. The change should be made at the root level (just after the workflow `name:` field) in `.github/workflows/pr.yml`, before the `on:` and `env:` blocks for maximum coverage and clarity. No additional imports or methods are needed, just this addition to the YAML metadata.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
